### PR TITLE
Run composer directly on the capistrano release

### DIFF
--- a/tools/capistrano/lib/inviqa_cap/composer.rb
+++ b/tools/capistrano/lib/inviqa_cap/composer.rb
@@ -10,15 +10,12 @@ module InviqaCap
         namespace :inviqa do
           namespace :composer do
             task :setup do
-              run "mkdir -p #{shared_path}/composer"
               run "cd #{shared_path} && curl -sS https://getcomposer.org/installer | php"
             end
 
             task :install do
-              run "cp #{latest_release}/composer.* #{shared_path}/composer"
               run "cd #{shared_path} && php #{shared_path}/composer.phar self-update"
-              run "cd #{shared_path}/composer && php #{shared_path}/composer.phar install --no-dev --optimize-autoloader"
-              run "cp -R #{shared_path}/composer/* #{latest_release}"
+              run "cd #{latest_release} && php #{shared_path}/composer.phar install --no-dev --optimize-autoloader"
             end
           end
         end

--- a/tools/capistrano/lib/inviqa_cap/composer.rb
+++ b/tools/capistrano/lib/inviqa_cap/composer.rb
@@ -4,18 +4,19 @@ module InviqaCap
   class Composer
     def self.load_into(config)
       config.load do
+        _cset(:composer_home) { "#{shared_path}/composer" }
         after "deploy:setup", "inviqa:composer:setup"
         after "deploy:finalize_update", "inviqa:composer:install"
 
         namespace :inviqa do
           namespace :composer do
             task :setup do
-              run "cd #{shared_path} && curl -sS https://getcomposer.org/installer | php"
+              run "cd #{shared_path} && curl -sS https://getcomposer.org/installer | /usr/bin/env COMPOSER_HOME=#{composer_home} php"
             end
 
             task :install do
-              run "cd #{shared_path} && php #{shared_path}/composer.phar self-update"
-              run "cd #{latest_release} && php #{shared_path}/composer.phar install --no-dev --optimize-autoloader"
+              run "cd #{shared_path} && COMPOSER_HOME=#{composer_home} php #{shared_path}/composer.phar self-update"
+              run "cd #{latest_release} && COMPOSER_HOME=#{composer_home} php #{shared_path}/composer.phar install --no-dev --optimize-autoloader"
             end
           end
         end


### PR DESCRIPTION
Composer introduced ~/.composer/cache/files/ to store downloaded packages so reinstalls will use it as cache.

This means the capistrano composer tasks don't need to keep their own cache directory, and can instead rely on the built-in cache.