### PR TITLE
Add capistrano notifications and interactively choosing a branch

### DIFF
--- a/tools/capistrano/config/deploy.rb
+++ b/tools/capistrano/config/deploy.rb
@@ -5,6 +5,7 @@ require 'capistrano/ext/multistage'
 require 'inviqa_cap/composer'
 require 'inviqa_cap/interactive'
 require 'inviqa_cap/notify_slack'
+require 'inviqa_cap/notify_newrelic'
 
 set :repository, "{{git_url}}"
 set :scm, :git

--- a/tools/capistrano/config/deploy.rb
+++ b/tools/capistrano/config/deploy.rb
@@ -3,6 +3,7 @@ set :default_stage, "dev"
 
 require 'capistrano/ext/multistage'
 require 'inviqa_cap/composer'
+require 'inviqa_cap/interactive'
 
 set :repository, "{{git_url}}"
 set :scm, :git

--- a/tools/capistrano/config/deploy.rb
+++ b/tools/capistrano/config/deploy.rb
@@ -4,6 +4,7 @@ set :default_stage, "dev"
 require 'capistrano/ext/multistage'
 require 'inviqa_cap/composer'
 require 'inviqa_cap/interactive'
+require 'inviqa_cap/notify_slack'
 
 set :repository, "{{git_url}}"
 set :scm, :git

--- a/tools/capistrano/lib/inviqa_cap/interactive.rb
+++ b/tools/capistrano/lib/inviqa_cap/interactive.rb
@@ -1,0 +1,118 @@
+require 'capistrano'
+
+module InviqaCap
+  class Interactive
+    def self.load_into(config)
+      config.load do
+        set :local_user, 'Unknown'
+        set :comment, ''
+        set :is_production_deploy, false
+        set :is_interactive, true
+
+        namespace :inviqa do
+          namespace :interactive do
+            # Set the deployment branch interactively
+            task :set_deploy_branch do
+              set :branch, InviqaCap::Interactive.branch_to_deploy(branch) if is_interactive
+            end
+
+            # Get the username of the local user who is running capistrano
+            task :set_local_user do
+              set(:local_user) do
+                run_locally 'whoami'.strip
+              end
+            end
+
+            # Ask for a comment regarding the deployment, to aide in choosing environments.
+            task :set_comment do
+              if is_interactive && !is_production_deploy
+                set(:comment) do
+                  comment = Capistrano::CLI.ui.ask <<-QUESTION
+Please add a short comment. For example, how long do you need the environment for:
+                  QUESTION
+                  comment.strip
+                end
+                fetch(:comment)
+              end
+            end
+
+            desc 'Add deployed branch name and comment to branch.json in deployed site.'
+            task :tag_deployment_with_branch, roles: :app do
+              deployment_details = {
+                branch: branch,
+                comment: comment,
+                deployed_by: local_user
+              }
+
+              require 'json'
+              json_text = deployment_details.to_json
+
+              require 'shellwords'
+              escaped_json_text = Shellwords.escape(json_text)
+              run "echo '#{escaped_json_text}' > #{latest_release}/branch.json"
+            end
+
+            # Confirm that the user actually wanted to run tasks on or deploy to production.
+            task :confirm_production_deploy do
+              if is_production_deploy
+                set(:confirmed) do
+                  puts <<-WARN
+==============================================================
+  WARNING: You're about to perform actions on production.
+  Please confirm that your intentions are kind and friendly.
+==============================================================
+                  WARN
+                  answer = Capistrano::CLI.ui.ask '  Are you sure you want to continue? (Y/[N]) '
+                  answer.casecmp('y') == 0
+                end
+
+                unless fetch(:confirmed)
+                  puts "\nDeploy cancelled!"
+                  exit
+                end
+              end
+            end
+          end
+        end
+
+        before 'deploy', 'inviqa:interactive:set_deploy_branch'
+        before 'deploy', 'inviqa:interactive:set_local_user'
+        before 'deploy', 'inviqa:interactive:set_comment'
+        before 'deploy', 'inviqa:interactive:confirm_production_deploy'
+      end
+    end
+
+    def self.naturalize(s)
+      s.scan(/[^\d\.]+|[\d]+/).collect { |f| f =~ /\d+/ ? f.to_i : f }
+    end
+
+    def self.natural_cmp(a, b)
+      (naturalize a) <=> (naturalize b)
+    end
+
+    def self.last_release_branch?
+      release_branches = `git show-ref | grep --color=never '/remotes/.*/release/' | awk '{print $2;}'`
+      branch = release_branches.split("\n").sort { |a, b| natural_cmp a, b }.last.to_s
+      branch
+    end
+
+    def self.confirmed_branch?(branch)
+      print "  Choose a branch to deploy [#{branch}]: "
+      confirmation = $stdin.gets.strip!
+      branch = confirmation unless confirmation.empty?
+      branch
+    end
+
+    def self.branch_to_deploy(default_branch = '')
+      branch = default_branch
+      branch = last_release_branch? if !branch || branch == ''
+      branch = 'master' if branch.empty?
+
+      confirmed_branch?(branch)
+    end
+  end
+end
+
+if Capistrano::Configuration.instance
+  InviqaCap::Interactive.load_into(Capistrano::Configuration.instance)
+end

--- a/tools/capistrano/lib/inviqa_cap/interactive.rb
+++ b/tools/capistrano/lib/inviqa_cap/interactive.rb
@@ -47,9 +47,7 @@ Please add a short comment. For example, how long do you need the environment fo
               require 'json'
               json_text = deployment_details.to_json
 
-              require 'shellwords'
-              escaped_json_text = Shellwords.escape(json_text)
-              run "echo '#{escaped_json_text}' > #{latest_release}/branch.json"
+              run "echo '#{json_text}' > #{latest_release}/branch.json"
             end
 
             # Confirm that the user actually wanted to run tasks on or deploy to production.

--- a/tools/capistrano/lib/inviqa_cap/notify_newrelic.rb
+++ b/tools/capistrano/lib/inviqa_cap/notify_newrelic.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+require 'capistrano'
+
+module InviqaCap
+  class NotifyNewrelic
+    def self.load_into(config)
+      config.load do
+        set :new_relic_api_key, ''
+
+        after 'deploy', 'inviqa:notifications:notify_newrelic'
+
+        namespace :inviqa do
+          namespace :notifications do
+            task :notify_newrelic, except: { no_release: true } do
+              if exists?(:new_relic_api_key) && exists?(:new_relic_application_id)
+                require 'shellwords'
+                escaped_branch = Shellwords.escape(branch)
+                escaped_user = Shellwords.escape(local_user)
+                run "curl -H 'x-api-key:#{new_relic_api_key}'"\
+                    " -d 'deployment[application_id]=#{new_relic_application_id}'"\
+                    " -d 'deployment[description]=#{escaped_branch}'"\
+                    " -d 'deployment[revision]=#{real_revision[0, 7]}'"\
+                    " -d 'deployment[user]=#{escaped_user}'"\
+                    " https://api.newrelic.com/deployments.xml"
+              else
+                puts "No New Relic API configuration found. Deployment event NOT sent."
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if Capistrano::Configuration.instance
+  InviqaCap::NotifyNewrelic.load_into(Capistrano::Configuration.instance)
+end

--- a/tools/capistrano/lib/inviqa_cap/notify_slack.rb
+++ b/tools/capistrano/lib/inviqa_cap/notify_slack.rb
@@ -129,10 +129,7 @@ module InviqaCap
                 require 'json'
                 json_text = json_payload.to_json
 
-                require 'shellwords'
-                escaped_json_text = Shellwords.escape(json_text)
-
-                run_locally "curl -X POST --data 'payload=#{escaped_json_text}' #{slack_hook_url}"
+                run_locally "curl -X POST --data 'payload=#{json_text}' #{slack_hook_url}"
               else
                 puts 'Skipping Slack Notification'
               end

--- a/tools/capistrano/lib/inviqa_cap/notify_slack.rb
+++ b/tools/capistrano/lib/inviqa_cap/notify_slack.rb
@@ -1,0 +1,149 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+require 'capistrano'
+
+module InviqaCap
+  class NotifySlack
+    def self.load_into(config)
+      config.load do
+        set :domain, 'example.com'
+        set :slack_channel, '#general'
+        set :github_url, 'https://github.com/inviqa/hem-seed-default'
+        set :jira_url, 'https://example.com/'
+        set :jira_project, '\\(PROJECT1|PROJECT2|PROJECT3\\)' # regular expression!
+
+        set :slack_hook_url, 'https://hooks.slack.com/services/.../.../...'
+
+        # Notify the development team about this release?
+        set :notify_development, true
+
+        after 'deploy', 'inviqa:notifications:notify_slack'
+
+        namespace :inviqa do
+          namespace :notifications do
+            task :notify_slack, except: { no_release: true } do
+              if notify_development
+                puts 'Notifying Slack:'
+
+                authors = ''
+                if previous_revision
+                  authors = capture(
+                    "cd #{shared_path}/cached-copy && git log #{previous_revision[0, 7]}..#{current_revision[0, 7]}"\
+                    ' --format=\"%aN\" | sort | uniq',
+                    hosts: [roles[:app].servers.first]
+                  )
+                end
+
+                contributors = ''
+                authors.each_line do |line|
+                  line.delete!('";')
+                  line.strip!
+                  line.gsub!("'", '\u0027')
+                  contributors = "#{contributors}, #{line}"
+                end
+
+                if contributors.to_s == ''
+                  contributors = 'None'
+                else
+                  contributors[0] = ''
+                end
+
+                log = ''
+                if previous_revision
+                  log = capture(
+                    "cd #{shared_path}/cached-copy && git log #{previous_revision[0, 7]}..#{current_revision[0, 7]}"\
+                    " --format=\"%s\" | grep -oh '#{jira_project}-[0-9]\\+' | sort | uniq",
+                    hosts: [roles[:app].servers.first]
+                  )
+                end
+
+                tickets = ''
+                log.each_line do |line|
+                  line.delete!('";')
+                  line.strip!
+                  line.gsub!("'", '\u0027')
+                  tickets = "#{tickets}, <#{jira_url}/#{line}|#{line}>"
+                end
+
+                if tickets.to_s == ''
+                  tickets = 'None'
+                else
+                  tickets[0] = ''
+                end
+
+                replaced_revision = ''
+                compare_link = ''
+                if previous_revision
+                  replaced_revision = " (replacing #{previous_revision[0, 7]})"
+                  compare_link = "(<#{github_url}/compare/#{previous_revision[0, 7]}..."\
+                                 "#{current_revision[0, 7]}|View Changes>)"
+                end
+
+                json_payload = {
+                  channel: slack_channel,
+                  text: "Deployment to <https://#{domain}> complete",
+                  attachments: [
+                    {
+                      fallback: "Deployed revision #{current_revision[0, 7]} from branch #{branch}#{replaced_revision}",
+                      color: '#45B5D2',
+                      fields: [
+                        {
+                          title: 'Branch Deployed',
+                          value: "<#{github_url}/tree/#{branch}|#{branch}>",
+                          short: true
+                        },
+                        {
+                          title: 'Revision',
+                          value: "<#{github_url}/commits/#{current_revision}|#{current_revision[0, 7]}>#{compare_link}",
+                          short: true
+                        }
+                      ]
+                    }
+                  ]
+                }
+
+                json_payload[:attachments][0][:fields] << {
+                  title: 'Deployed By',
+                  value: local_user,
+                  short: true
+                } if local_user
+
+                json_payload[:attachments][0][:fields] << {
+                  title: 'Comment',
+                  value: comment,
+                  short: false
+                } if comment
+
+                json_payload[:attachments][0][:fields] << {
+                  title: 'Contributors',
+                  value: contributors,
+                  short: false
+                }
+                json_payload[:attachments][0][:fields] << {
+                  title: 'Tickets',
+                  value: tickets,
+                  short: false
+                }
+
+                require 'json'
+                json_text = json_payload.to_json
+
+                require 'shellwords'
+                escaped_json_text = Shellwords.escape(json_text)
+
+                run_locally "curl -X POST --data 'payload=#{escaped_json_text}' #{slack_hook_url}"
+              else
+                puts 'Skipping Slack Notification'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if Capistrano::Configuration.instance
+  InviqaCap::NotifySlack.load_into(Capistrano::Configuration.instance)
+end


### PR DESCRIPTION
Ability to:
1) Choose a branch to deploy interactively. `-Sbranch=<branch>` still works in non-interactive mode.
2) Add a comment about the deployment, such as how long a test environment is needed for. This will get stored in a "branch.json" file in the root of the deployed site.
3) Notify a Slack channel at the end of a successful deployment.
4) Notify a Newrelic application at the end of a successful deployment.