### PR TITLE
Install java if elasticsearch is requested.

### DIFF
--- a/tools/chef/Berksfile
+++ b/tools/chef/Berksfile
@@ -15,6 +15,7 @@ cookbook 'redisio', '~> 2.4.2'
 cookbook 'memcached', '~> 2.1.0'
 cookbook 'nginx', '2.4.2'
 cookbook 'apache2', '~> 3.2'
+cookbook 'java', '~> 1.39'
 cookbook 'elasticsearch', '~> 0.3.7'
 cookbook 'data-bag-merge', '~> 0.2.4'
 

--- a/tools/chef/Berksfile.lock
+++ b/tools/chef/Berksfile.lock
@@ -7,6 +7,7 @@ DEPENDENCIES
   config-driven-helper (~> 2.0)
   data-bag-merge (~> 0.2.4)
   elasticsearch (~> 0.3.7)
+  java (~> 1.39)
   jetty
     git: git://github.com/inviqa/chef-jetty.git
     revision: de58c6923d4c6387deabb7ace92ee051a408328d

--- a/tools/chef/roles/elasticsearch.json
+++ b/tools/chef/roles/elasticsearch.json
@@ -13,6 +13,7 @@
     }
   },
   "run_list": [
+    "recipe[java]",
     "recipe[elasticsearch]"
   ]
 }


### PR DESCRIPTION
Without java:
```
$ sudo service elasticsearch start
Starting Elasticsearch...which: no java in (/sbin:/usr/sbin:/bin:/usr/bin)
Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME
 [OK]
```