### PR TITLE
Support upgrade/downgrade of php packages

### DIFF
--- a/tools/chef/roles/php-upgrade.json
+++ b/tools/chef/roles/php-upgrade.json
@@ -1,0 +1,29 @@
+{
+  "name": "php-upgrade",
+  "chef_type": "role",
+  "json_class": "Chef::Role",
+  "description": "PHP upgrader",
+  "default_attributes": {
+    "php": {
+      "replace_packages": [
+        "php-common",
+        "php54-common",
+        "php54w-common",
+        "php54u-common",
+        "php55u-common",
+        "php56u-common"
+      ]
+    },
+    "package_replacements": {
+      "php": {
+        "enabled": true,
+        "from": "replace_packages",
+        "to": "replace_package_target"
+      }
+    }
+  },
+  "run_list": [
+    "yum-webtatic",
+    "package-replace"
+  ]
+}

--- a/tools/chef/roles/php55.json
+++ b/tools/chef/roles/php55.json
@@ -6,21 +6,9 @@
   "default_attributes": {
     "php": {
       "replace_packages": [
-        "php-common",
-        "php54-common",
-        "php54w-common",
-        "php54u-common",
-        "php56w-common",
-        "php56u-common"
+        "php56w-common"
       ],
       "replace_package_target": "php55w-common"
-    },
-    "package_replacements": {
-      "php": {
-        "enabled": true,
-        "from": "replace_packages",
-        "to": "replace_package_target"
-      }
     }
   },
   "override_attributes": {
@@ -50,8 +38,7 @@
     }
   },
   "run_list": [
-    "yum-webtatic",
-    "package-replace",
-    "php"
+    "role[php-upgrade]",
+    "recipe[php]"
   ]
 }

--- a/tools/chef/roles/php55.json
+++ b/tools/chef/roles/php55.json
@@ -3,6 +3,26 @@
   "chef_type": "role",
   "json_class": "Chef::Role",
   "description": "PHP5.5 role",
+  "default_attributes": {
+    "php": {
+      "replace_packages": [
+        "php-common",
+        "php54-common",
+        "php54w-common",
+        "php54u-common",
+        "php56w-common",
+        "php56u-common"
+      ],
+      "replace_package_target": "php55w-common"
+    },
+    "package_replacements": {
+      "php": {
+        "enabled": true,
+        "from": "replace_packages",
+        "to": "replace_package_target"
+      }
+    }
+  },
   "override_attributes": {
     "php-fpm": {
       "package_name": "php55w-fpm"
@@ -31,6 +51,7 @@
   },
   "run_list": [
     "yum-webtatic",
+    "package-replace",
     "php"
   ]
 }

--- a/tools/chef/roles/php56.json
+++ b/tools/chef/roles/php56.json
@@ -6,22 +6,9 @@
   "default_attributes": {
     "php": {
       "replace_packages": [
-        "php-common",
-        "php54-common",
-        "php54w-common",
-        "php54u-common",
-        "php55-common",
-        "php55w-common",
-        "php55u-common"
+        "php55w-common"
       ],
       "replace_package_target": "php56w-common"
-    },
-    "package_replacements": {
-      "php": {
-        "enabled": true,
-        "from": "replace_packages",
-        "to": "replace_package_target"
-      }
     }
   },
   "override_attributes": {
@@ -51,8 +38,7 @@
     }
   },
   "run_list": [
-    "yum-webtatic",
-    "package-replace",
-    "php"
+    "role[php-upgrade]",
+    "recipe[php]"
   ]
 }

--- a/tools/chef/roles/php56.json
+++ b/tools/chef/roles/php56.json
@@ -3,6 +3,27 @@
   "chef_type": "role",
   "json_class": "Chef::Role",
   "description": "PHP5.6 role",
+  "default_attributes": {
+    "php": {
+      "replace_packages": [
+        "php-common",
+        "php54-common",
+        "php54w-common",
+        "php54u-common",
+        "php55-common",
+        "php55w-common",
+        "php55u-common"
+      ],
+      "replace_package_target": "php56w-common"
+    },
+    "package_replacements": {
+      "php": {
+        "enabled": true,
+        "from": "replace_packages",
+        "to": "replace_package_target"
+      }
+    }
+  },
   "override_attributes": {
     "php-fpm": {
       "package_name": "php56w-fpm"
@@ -31,6 +52,7 @@
   },
   "run_list": [
     "yum-webtatic",
+    "package-replace",
     "php"
   ]
 }

--- a/tools/chef/roles/web-apache.json
+++ b/tools/chef/roles/web-apache.json
@@ -20,7 +20,14 @@
     },
     "packages": [
       "mod_realdoc"
-    ]
+    ],
+    "package_replacements": {
+      "php": {
+        "notify": {
+          "service[apache2]": "restart"
+        }
+      }
+    }
   },
   "run_list": [
     "recipe[yum-webtatic]",

--- a/tools/chef/roles/web-nginx.json
+++ b/tools/chef/roles/web-nginx.json
@@ -32,6 +32,13 @@
     "services": {
       "nginx": ["enable", "start"],
       "php-fpm": ["enable", "start"]
+    },
+    "package_replacements": {
+      "php": {
+        "notify": {
+          "service[php-fpm]": "restart"
+        }
+      }
     }
   },
   "run_list": [


### PR DESCRIPTION
As per #63, use https://github.com/inviqa/chef-package-replace to upgrade or downgrade the php packages to webtatic's 5.5 or 5.6.

To switch php versions, simply switch out the php55 and php55-development roles for php56 and php56-development and it will handle the upgrade on the next chef run.

This should also upgrade from PHP 5.3 or 5.4 relatively easily as well!