### PR TITLE
Switch to iptables-patterns cookbook

### DIFF
--- a/tools/chef/Berksfile
+++ b/tools/chef/Berksfile
@@ -25,6 +25,7 @@ cookbook 'jetty', :github => 'inviqa/chef-jetty', :tag => '0.2'
 cookbook 'solr', :github => 'inviqa/chef-solr', :tag => '1.0.1'
 cookbook 'chef-varnish', :github => 'inviqa/chef-varnish', :ref => '1.0.5'
 cookbook 'config-driven-helper', '~> 2.0'
+cookbook 'iptables-patterns', '~> 0.1.0'
 cookbook 'php-fpm', '~> 0.7.5'
 
 cookbook 'project', :path => 'site-cookbooks/project'

--- a/tools/chef/nodes/development.local.json
+++ b/tools/chef/nodes/development.local.json
@@ -1,6 +1,5 @@
 {
   "run_list": [
-    "role[project-pipeline]",
     "role[project-db]",
     "role[project-web]",
     "role[project-development]"

--- a/tools/chef/roles/project-base.json
+++ b/tools/chef/roles/project-base.json
@@ -5,7 +5,8 @@
   "description": "<%= config.name %> base role",
   "run_list": [
     "recipe[data-bag-merge::environment]",
-    "recipe[config-driven-helper::iptables-standard]",
+    "recipe[iptables-patterns::fail2ban]",
+    "recipe[iptables-patterns::frontend_permissive_ports]",
     "recipe[ntp]",
     "recipe[system::timezone]"
   ],

--- a/tools/chef/roles/project-development.json.erb
+++ b/tools/chef/roles/project-development.json.erb
@@ -1,8 +1,8 @@
 {
-  "name": "project-db",
+  "name": "project-development",
   "chef_type": "role",
   "json_class": "Chef::Role",
-  "description": "<%= config.name %> db role",
+  "description": "<%= config.name %> development role",
   "default_attributes": {
     "iptables-standard": {
       "allowed_incoming_ports": {
@@ -11,6 +11,7 @@
     }
   },
   "run_list": [
+    "recipe[yum-cron]",
     "recipe[iptables-patterns::fail2ban]",
     "recipe[iptables-patterns::frontend_permissive_ports]",
     "recipe[mailcatcher-ng]",

--- a/tools/chef/roles/project-development.json.erb
+++ b/tools/chef/roles/project-development.json.erb
@@ -11,9 +11,8 @@
     }
   },
   "run_list": [
+    "role[project-base]",
     "recipe[yum-cron]",
-    "recipe[iptables-patterns::fail2ban]",
-    "recipe[iptables-patterns::frontend_permissive_ports]",
     "recipe[mailcatcher-ng]",
     "recipe[mailcatcher-ng::postfix]",
     "role[php56-development]"

--- a/tools/chef/roles/project-development.json.erb
+++ b/tools/chef/roles/project-development.json.erb
@@ -11,7 +11,8 @@
     }
   },
   "run_list": [
-    "recipe[config-driven-helper::iptables-standard]",
+    "recipe[iptables-patterns::fail2ban]",
+    "recipe[iptables-patterns::frontend_permissive_ports]",
     "recipe[mailcatcher-ng]",
     "recipe[mailcatcher-ng::postfix]",
     "role[php56-development]"

--- a/tools/chef/roles/project-pipeline.json.erb
+++ b/tools/chef/roles/project-pipeline.json.erb
@@ -4,8 +4,7 @@
   "json_class": "Chef::Role",
   "description": "<%= config.name %> pipeline role",
   "run_list": [
-    "recipe[yum-cron]",
-    "recipe[iptables-patterns::fail2ban]",
-    "recipe[iptables-patterns::whitelist_ip_ports]"
+    "role[project-base]",
+    "recipe[yum-cron]"
   ]
 }

--- a/tools/chef/roles/project-pipeline.json.erb
+++ b/tools/chef/roles/project-pipeline.json.erb
@@ -4,6 +4,8 @@
   "json_class": "Chef::Role",
   "description": "<%= config.name %> pipeline role",
   "run_list": [
-    "recipe[yum-cron]"
+    "recipe[yum-cron]",
+    "recipe[iptables-patterns::fail2ban]",
+    "recipe[iptables-patterns::whitelist_ip_ports]"
   ]
 }


### PR DESCRIPTION
* Switch to iptables-patterns cookbook ( https://supermarket.chef.io/cookbooks/iptables-patterns ) rather than config-driven-helper::iptables-standard
* Now that pipeline can be locked down based on config, copy the yum-cron recipe from pipeline to the development role and stop calling pipeline from the development node.