### PR TITLE
Remove MySQL anonymous users and test db

### DIFF
--- a/tools/chef/roles/db-mysql55-server.json
+++ b/tools/chef/roles/db-mysql55-server.json
@@ -10,6 +10,8 @@
   },
   "override_attributes": {
     "mysql": {
+      "remove_anonymous_users": true,
+      "remove_test_database": true,
       "server": {
         "packages": [
           "mysql55-devel",

--- a/tools/chef/roles/db-mysql56-server.json
+++ b/tools/chef/roles/db-mysql56-server.json
@@ -10,6 +10,8 @@
   },
   "override_attributes": {
     "mysql": {
+      "remove_anonymous_users": true,
+      "remove_test_database": true,
       "version": "5.6",
       "server": {
         "slow_query_log": true,


### PR DESCRIPTION
This only happens on initial install. An existing db server will retain these if they previously existed.

Although the MySQL port shouldn't be exposed outside a network, these are never used, and only add an unnecessary attack surface.