### PR TITLE
Remove cdh::services from memcache role

### DIFF
--- a/tools/chef/roles/memcache.json
+++ b/tools/chef/roles/memcache.json
@@ -3,13 +3,7 @@
   "chef_type": "role",
   "json_class": "Chef::Role",
   "description": "Memcache server role",
-  "default_attributes": {
-    "services": {
-      "memcached": [ "enable", "start" ]
-    }
-  },
   "run_list": [
-    "recipe[memcached]",
-    "recipe[config-driven-helper::services]"
+    "recipe[memcached]"
   ]
 }


### PR DESCRIPTION
memcached cookbook v2.1 now correctly enables and starts it's service, so config-driven-helper::services doesn't need to manage it.

This was causing race-conditions under certain situations.