### PR TITLE
Add preserve_host to nginx ssl_offload config

### DIFF
--- a/tools/chef/roles/web-nginx-ssl-offload.json
+++ b/tools/chef/roles/web-nginx-ssl-offload.json
@@ -19,7 +19,8 @@
               "type": "path_not_regex",
               "mode": "reverse-proxy",
               "proxy": {
-                "location": "http://127.0.0.1"
+                "location": "http://127.0.0.1",
+                "preserve_host": true
               }
             }
           }


### PR DESCRIPTION
This was missed when I changed the behaviour of the reverse proxy to disable it by default