### PR TITLE
Use the default Nginx package now that it's more up to date

### DIFF
--- a/tools/chef/roles/web-nginx-ssl-offload.json
+++ b/tools/chef/roles/web-nginx-ssl-offload.json
@@ -5,7 +5,6 @@
   "description": "Nginx HTTP server role for SSL offloading",
   "default_attributes": {
     "nginx": {
-      "package": "nginx18",
       "default_site_enabled": false,
       "https_variable_emulation": false,
       "shared_config": {

--- a/tools/chef/roles/web-nginx.json
+++ b/tools/chef/roles/web-nginx.json
@@ -5,7 +5,6 @@
   "description": "Nginx HTTP server role",
   "default_attributes": {
     "nginx": {
-      "package_name": "nginx18",
       "default_site_enabled": false,
       "https_variable_emulation": false
     },


### PR DESCRIPTION
EPEL upgraded Nginx to 1.10 in CentOS 6/7