### PR TITLE
Enable vagrant cachier (missing config setting)

### DIFF
--- a/tools/chef/environments/development.json.erb
+++ b/tools/chef/environments/development.json.erb
@@ -33,6 +33,11 @@
     },
     "yum-cron": {
       "cleanday": 9
+    },
+    "yum": {
+      "main": {
+        "keepcache": true
+      }
     }
   },
 

--- a/tools/vagrant/Vagrantfile.erb
+++ b/tools/vagrant/Vagrantfile.erb
@@ -16,9 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # vagrant-hostsupdater settings
   config.vm.hostname = "<%= config.hostname %>"
   # config.hostsupdater.aliases = []
-
-  # vagrant-cachier settings
-  config.cache.auto_detect = true
+  
 
   # Mount settings
   nfs_version = 3
@@ -30,6 +28,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'inviqa/centos-7-stack-php56'
   config.vm.box_version = '~> 1.0'
 
+  # vagrant-cachier settings
+  config.cache.scope = :box
+  config.cache.auto_detect = true
+  config.cache.synced_folder_opts = {
+    type: :nfs,
+    mount_options: ['rw', "vers=#{nfs_version}", 'tcp', 'nolock']
+  } unless FFI::Platform::IS_WINDOWS
+
   # Virtualbox specific configuration
   config.vm.provider :virtualbox do |vb, overrides|
     #vb.gui = true
@@ -40,7 +46,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     overrides.vm.network :private_network, ip: "<%= config.vm_ip %>", netmask: "255.255.0.0"
     overrides.ssh.forward_agent = true
 
-    # Shared folders
     overrides.vm.synced_folder(
       "../../",
       "/vagrant",

--- a/tools/vagrant/Vagrantfile.erb
+++ b/tools/vagrant/Vagrantfile.erb
@@ -23,14 +23,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   nfs_version = 4 if FFI::Platform::IS_LINUX
   mount_options = { mount_options: ["dmode=777", "fmode=777"] }
   mount_options = { nfs: true, nfs_version: nfs_version, nfs_udp: false } unless FFI::Platform::IS_WINDOWS
-  
+
   # Box configuration
   config.vm.box = 'inviqa/centos-7-stack-php56'
   config.vm.box_version = '~> 1.0'
 
   # vagrant-cachier settings
   config.cache.scope = :box
-  config.cache.auto_detect = true
+  config.cache.auto_detect = false
+  [:composer, :npm, :bower, :yum, :chef].each do |cache|
+    config.cache.enable cache
+  end
   config.cache.synced_folder_opts = {
     type: :nfs,
     mount_options: ['rw', "vers=#{nfs_version}", 'tcp', 'nolock']


### PR DESCRIPTION
Enable vagrant-cachier, which requires `config.cache.scope` to function - the only thing that was missing.

Whilst ensuring vagrant-cachier is on, this PR also:
* enables NFS mounts for the cache directory for speed
* converts OSX NFS mountpoints to TCP
* ensures RPMs downloaded by yum are kept in the dev environment for vagrant cache
* use manual list of caches as config.cache.autodetect is running into a bug with rbenv inside the VM