### PR TITLE
Fix yum cron installation failure.

### DIFF
--- a/tools/chef/roles/project-base.json
+++ b/tools/chef/roles/project-base.json
@@ -9,11 +9,15 @@
     "recipe[iptables-patterns::fail2ban]",
     "recipe[iptables-patterns::frontend_permissive_ports]",
     "recipe[ntp]",
-    "recipe[system::timezone]"
+    "recipe[system::timezone]",
+    "recipe[config-driven-helper::packages-additional]"
   ],
   "default_attributes": {
     "system": {
       "timezone": "UTC"
+    },
+    "packages-additional": {
+      "yum": "upgrade"
     }
   }
 }


### PR DESCRIPTION
yum-cron fails to install due to:

```
  ==> default:     Chef::Exceptions::Exec
  ==> default:     ----------------------
  ==> default:     yum -d0 -e0 -y install yum-cron-3.4.3-150.el7.centos returned 1:
  ==> default:       
  ==> default: STDOUT: 
  ==> default:     STDERR: 
  ==> default:     
  ==> default:     Transaction check error:
  ==> default:       file /etc/yum/yum-cron-hourly.conf from install of yum-cron-3.4.3-150.el7.centos.noarch conflicts with file from package yum-3.4.3-132.el7.centos.0.1.noarch
  ==> default:       file /etc/yum/yum-cron.conf from install of yum-cron-3.4.3-150.el7.centos.noarch conflicts with file from package yum-3.4.3-132.el7.centos.0.1.noarch
```

We have been adhoc fixing it by upgrading yum or disabling yum-cron installation in places. This PR pulls in the upgrading of yum into new seed plants.

After doing `hem vm up` with a freshly planted default seed, the yum conflict was encountered. After doing `hem vm destroy` and implementing the fix in this PR, I was able to provision a VM successfully.