### PR TITLE
Declare ports for ContinuousPIpe

### DIFF
--- a/continuous-pipe.yml.erb
+++ b/continuous-pipe.yml.erb
@@ -106,6 +106,9 @@ tasks:
             accessibility:
               from_cluster: true
               from_external: false
+            ports:
+              - 1025
+              - 1080
 
             resources:
               limits:
@@ -123,6 +126,8 @@ tasks:
               limits:
                 cpu: 50m
                 memory: 100Mi
+            ports:
+              - 9135
 
           deployment_strategy:
             readiness_probe:


### PR DESCRIPTION
Now that docker-compose.yml does not declare ports, ContinuousPipe doesn't know what ports to create Kubernetes services with