### PR TITLE
Use empty values for external variables if unset

### DIFF
--- a/continuous-pipe.yml.erb
+++ b/continuous-pipe.yml.erb
@@ -44,11 +44,11 @@ tasks:
     build:
       environment:
         - name: GITHUB_TOKEN
-          value: ${GITHUB_TOKEN}
+          value: ${GITHUB_TOKEN?:}
         - name: AWS_ACCESS_KEY_ID
-          value: ${AWS_ACCESS_KEY_ID}
+          value: ${AWS_ACCESS_KEY_ID?:}
         - name: AWS_SECRET_ACCESS_KEY
-          value: ${AWS_SECRET_ACCESS_KEY}
+          value: ${AWS_SECRET_ACCESS_KEY?:}
         - name: ASSETS_S3_BUCKET
           value: ${ASSETS_S3_BUCKET}
         - name: ASSETS_ENV
@@ -95,8 +95,8 @@ tasks:
                 memory: 2Gi
 
             environment_variables:
-              MYSQL_PASSWORD: ${DATABASE_PASSWORD}
-              MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD}
+              MYSQL_PASSWORD: ${DATABASE_PASSWORD?:}
+              MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD?:}
               MYSQL_DATABASE: ${DATABASE_NAME}
               MYSQL_USER: ${DATABASE_USER}
 
@@ -144,7 +144,7 @@ tasks:
             ports:
               - 9000
             environment_variables:
-              SSH_FORWARD_PASSWORD: ${SSH_FORWARD_PASSWORD}
+              SSH_FORWARD_PASSWORD: ${SSH_FORWARD_PASSWORD?:}
 
           deployment_strategy:
             readiness_probe:
@@ -160,10 +160,10 @@ tasks:
           endpoints: &WEB_ENDPOINTS
             - name: web
               cloud_flare_zone:
-                zone_identifier: ${CLOUD_FLARE_ZONE}
+                zone_identifier: ${CLOUD_FLARE_ZONE?:}
                 authentication:
-                    email: ${CLOUD_FLARE_EMAIL}
-                    api_key: ${CLOUD_FLARE_API_KEY}
+                    email: ${CLOUD_FLARE_EMAIL?:}
+                    api_key: ${CLOUD_FLARE_API_KEY?:}
                 proxied: true
                 record_suffix: ${CP_ENVIRONMENT_DOMAIN_SUFFIX}
               ingress:
@@ -191,22 +191,22 @@ tasks:
 
           specification:
             environment_variables: &WEB_ENV_VARS
-              AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-              AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID?:}
+              AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY?:}
               ASSETS_S3_BUCKET: ${ASSETS_S3_BUCKET}
               ASSETS_ENV: ''
               APP_USER_LOCAL: false
               DATABASE_HOST: ${DATABASE_HOST}
               DATABASE_NAME: ${DATABASE_NAME}
               DATABASE_USER: ${DATABASE_USER}
-              DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+              DATABASE_PASSWORD: ${DATABASE_PASSWORD?:}
               DEVELOPMENT_MODE: ${DEVELOPMENT_MODE}
               AUTH_HTTP_ENABLED: true
-              AUTH_HTTP_HTPASSWD: ${AUTH_HTTP_HTPASSWD}
+              AUTH_HTTP_HTPASSWD: ${AUTH_HTTP_HTPASSWD?:}
               AUTH_IP_WHITELIST_ENABLED: true
-              AUTH_IP_WHITELIST: ${AUTH_IP_WHITELIST}
-              TRUSTED_REVERSE_PROXIES: ${TRUSTED_REVERSE_PROXIES}
-              TIDEWAYS_API_KEY: ${TIDEWAYS_API_KEY}
+              AUTH_IP_WHITELIST: ${AUTH_IP_WHITELIST?:}
+              TRUSTED_REVERSE_PROXIES: ${TRUSTED_REVERSE_PROXIES?:}
+              TIDEWAYS_API_KEY: ${TIDEWAYS_API_KEY?:}
               SENDMAIL_RELAY_HOST: ${SENDMAIL_RELAY_HOST}
 
             resources:


### PR DESCRIPTION
CP unusally just renders the string as literal, which is worse here than an empty variable

Given some of these are optional anyway, they could be empty by default in any case.